### PR TITLE
make git-wrapper a bit friendlier on old gits

### DIFF
--- a/lib/Git/Wrapper.pm
+++ b/lib/Git/Wrapper.pm
@@ -253,9 +253,16 @@ package Git::Wrapper::Exception;
 sub new { my $class = shift; bless { @_ } => $class }
 
 use overload (
-  q("") => 'error',
+  q("") => '_stringify',
   fallback => 1,
 );
+
+sub _stringify {
+  my ($self) = @_;
+  my $error = $self->error;
+  return $error if $error =~ /\S/;
+  return "git exited non-zero but had no output to stderr";
+}
 
 sub output { join "", map { "$_\n" } @{ shift->{output} } }
 sub error  { join "", map { "$_\n" } @{ shift->{error} } }


### PR DESCRIPTION
Right now, if you call `$git->status` on an old git, the program will immediately exit non-zero with no explanation.  The problem is that "git status" used to exit non-zero, but print only to stdout.

Here are two changes:
- cope with "git status" exiting nonzero
- stringify exceptions to something visible even if there was no stderr output
