### PR TITLE
Skip hash test on git versions before 1.6.1

### DIFF
--- a/lib/Git/Wrapper.pm
+++ b/lib/Git/Wrapper.pm
@@ -251,6 +251,14 @@ sub log {
   return @logs;
 }
 
+sub supports_hash_object_filters {
+  my $self = shift;
+
+  # The '--no-filters' option to 'git-hash-object' was added in version 1.6.1
+  return 0 if ( versioncmp( $self->version , '1.6.1' ) eq -1 );
+  return 1;
+}
+
 sub supports_log_raw_dates {
   my $self = shift;
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -151,12 +151,16 @@ $new_branch =~ s/^\*\s+|\s+$//g;
 
 is $new_branch, 'new_branch', 'new branch name is correct';
 
-my ($hash) = $git->hash_object({
-  no_filters => 1,
-  stdin      => 1,
-  -STDIN     => 'content to hash',
-});
-is $hash, '4b06c1f876b16951b37f4d6755010f901100f04e',
-  'passing content with -STDIN option';
+SKIP: {
+  skip 'testing old git without no-filters' , 1 unless $git->supports_hash_object_filters;
+
+  my ($hash) = $git->hash_object({
+    no_filters => 1,
+    stdin      => 1,
+    -STDIN     => 'content to hash',
+  });
+  is $hash, '4b06c1f876b16951b37f4d6755010f901100f04e',
+    'passing content with -STDIN option';
+}
 
 done_testing();


### PR DESCRIPTION
Did some figurin', and the no-filters option seems to have shown up:

http://git-scm.com/docs/git-hash-object/1.6.1

Because when we go to:

http://git-scm.com/docs/git-hash-object/1.6.0

It doesn't show up.  Added a method that tests support on the version number per the suggestions in https://github.com/genehack/Git-Wrapper/issues/16 and modified the test to skip if unsupported.
