### PR TITLE
Prevent \n munging in test

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -23,9 +23,13 @@ $git->init;
 $git->config( 'user.name'  , 'Test User'        );
 $git->config( 'user.email' , 'test@example.com' );
 
+# make sure git isn't munging our content so we have consistent hashes
+$git->config( 'core.autocrlf' , 'false' );
+$git->config( 'core.safecrlf' , 'false' );
+
 mkpath(File::Spec->catfile($dir, 'foo'));
 
-IO::File->new(">" . File::Spec->catfile($dir, qw(foo bar)))->print("hello\n");
+IO::File->new(File::Spec->catfile($dir, qw(foo bar)), '>:raw')->print("hello\n");
 
 is_deeply(
   [ $git->ls_files({ o => 1 }) ],


### PR DESCRIPTION
Prevent any alterations to \n in file output or git internally to ensure we get consistent hashes.

Fixes issue #18.
