### PR TITLE
wrap unset of GIT_PAGER_IN_USE a lexical warnings disabler

### DIFF
--- a/lib/Git/Wrapper.pm
+++ b/lib/Git/Wrapper.pm
@@ -9,7 +9,7 @@ our $DEBUG=0;
 
 # Prevent ANSI color with extreme prejudice
 # https://github.com/genehack/Git-Wrapper/issues/13
-$ENV{GIT_PAGER_IN_USE} = undef;
+{ no warnings 'uninitialized'; $ENV{GIT_PAGER_IN_USE} = undef; }
 
 use File::pushd;
 use File::Temp;


### PR DESCRIPTION
Under 5.8 perls, doing

$ENV{GIT_PAGER_IN_USE} = undef

produces this warning:

Use of uninitialized value in scalar assignment at /home/jfitzgib/perlbrew/pkg/lib/5.8.8-linux-x86_64-linux-thread-multi/lib/perl5/Git/Wrapper.pm line 16.
