### PR TITLE
Prevent a test in t/basic.t from potentially failing

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -143,7 +143,9 @@ for my $arg_test (@arg_tests) {
 
 $git->checkout({b => 'new_branch'});
 
-my ($new_branch) = grep {m/^\*/} $git->branch;
+my ($new_branch) =
+    grep {m/^\*/}
+    $git->branch( { color => 'never' } ); # No ANSI color escapes
 $new_branch =~ s/^\*\s+|\s+$//g;
 
 is $new_branch, 'new_branch', 'new branch name is correct';


### PR DESCRIPTION
In parsing the output from 'branch', a test was failing if the Git configuration branch.color was set to 'always'.

I have related comments in issue #13 in the genehack/Git-Wrapper repository.
