### PR TITLE
fix $git->branch compatibility with git < 1.7.1

### DIFF
--- a/lib/Git/Wrapper.pm
+++ b/lib/Git/Wrapper.pm
@@ -199,7 +199,7 @@ sub branch {
   my $self = shift;
 
   my $opt = ref $_[0] eq 'HASH' ? shift : {};
-  $opt->{color} = 'never';
+  $opt->{no_color} = 1;
 
   return $self->RUN(branch => $opt,@_);
 }


### PR DESCRIPTION
This is a fix for #27 issue.
`$git->branch` now calls `git branch --no-color` instead of `git branch --color=never`.
