### PR TITLE
Fix basic.t for running on Windows, or with an older git version

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -127,6 +127,10 @@ SKIP: {
 }
 
 SKIP: {
+    if ( versioncmp( $git->version , '1.7.0.5') eq -1 ) {
+      skip 'testing old git without commit --allow-empty-message support' , 1;
+    }
+
     # Test empty commit message
     IO::File->new(">" . File::Spec->catfile($dir, qw(second_commit)))->print("second_commit\n");
     $git->add('second_commit');


### PR DESCRIPTION
There is no executable bit on Windows, so including it in tests is rather fragile.

Also `git commit --allow-empty-message` requires 1.7.0.5 or later (and combining it with --amend is broken until an even later version, but the test doesn't use --amend).
