### PR TITLE
Avoid running interactively

### DIFF
--- a/lib/Git/Wrapper.pm
+++ b/lib/Git/Wrapper.pm
@@ -98,6 +98,9 @@ sub RUN {
 
     print STDERR join(' ',@cmd),"\n" if $DEBUG;
 
+    # Prevent commands from running interactively
+    local $ENV{GIT_EDITOR} = '';
+
     my $pid = IPC::Open3::open3($wtr, $rdr, $err, @cmd);
     print $wtr $stdin
       if defined $stdin;


### PR DESCRIPTION
Setting GIT_EDITOR to an empty string should suppress attempts to run
any commands interactively. Test that we fail to run known interactive
commands without hanging indefinitely.
