### PR TITLE
exit 0 in Makefile.PL when 'git' executable not present

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
 
+        bail out early in Makefile.PL if git not installed, instead of failing
+        tests (Karen Etheridge)
+
 0.025     2012-07-18 12:38:05 America/New_York
 
         Add 'fatal' option for RequiresExternal dzil plugin

--- a/dist.ini
+++ b/dist.ini
@@ -37,6 +37,5 @@ copy = README.mkdn
 [Git::Commit]
 [Git::Tag]
 [Twitter]
-[RequiresExternal]
-requires = git
-fatal = 1
+[CheckBin]
+command = git


### PR DESCRIPTION
This will result in NA CPAN Testers reports instead of failures.
