### PR TITLE
Fix typo in minimum version required of File::pushd

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -23,7 +23,7 @@ command = git
 
 [AutoPrereqs]
 [Prereqs]
-File::pushd = 1.05
+File::pushd = 1.005
 [Prereqs / TestRecommends]
 Path::Class = 0.26
 [GithubMeta]


### PR DESCRIPTION
Minimum required version of File::pushd should have been 1.005 (whereas 1.05 doesn't exist).

A plugin like `Dist::Zilla::Plugin::Test::CheckDeps` would have caught this (there are probably others too).
