### PR TITLE
cross-platform auto-commit in dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -51,4 +51,4 @@ run = rm -f Makefile.PL
 
 [Run::AfterBuild]
 run = cp %d/Makefile.PL ./
-run = git status --porcelain | grep 'M Makefile.PL' && git commit -m 'auto-committed by dist.ini' Makefile.PL || echo Makefile.PL up to date
+run = git status --porcelain | grep "M Makefile.PL" && git commit -m "auto-committed by dist.ini" Makefile.PL || echo Makefile.PL up to date


### PR DESCRIPTION
Apostrophes don't quote on Windows, but quotes quote everywhere. :)
