### PR TITLE
fix Makefile.PL when no global .gitconfig exists

### DIFF
--- a/inc/CheckGitConfig.pm
+++ b/inc/CheckGitConfig.pm
@@ -12,7 +12,7 @@ around _build_MakeFile_PL_template => sub {
 my $git_check = <<GIT_CHECK;
 require File::Spec;
 die 'git seems broken; maybe check your HOME environment variable?'
-    if system('git config --global --list >'.File::Spec->devnull);
+    if system('git config --list >'.File::Spec->devnull);
 
 GIT_CHECK
 


### PR DESCRIPTION
If no global .gitconfig file exists, git config --global will die with
an error.  As long as we don't specify the global flag, a nonexistent
global config will be ignored, but it will still fail if a broken $HOME
is set.
