### PR TITLE
Fix single letter options

### DIFF
--- a/lib/Git/Wrapper.pm
+++ b/lib/Git/Wrapper.pm
@@ -319,11 +319,10 @@ sub _opt_and_val {
       : "--$name"
         ;
 
-  my $value = $val eq '1' ? ""
-    : length($name) == 1 ? $val
-      :                      "=$val";
-
-  return $opt . $value;
+  return
+      $val eq '1' ? ($opt)
+    : length($name) == 1 ? ($opt, $val)
+    :                      "$opt=$val";
 }
 
 sub _parse_args {

--- a/t/parse_args.t
+++ b/t/parse_args.t
@@ -45,7 +45,7 @@ my @data = (
   ] ,
   [
     [ 'status' , { -a => 1, -b => 'foo', -cd => 1, -ef => 'foo', g => 1, h => 'bar', ij => 1, jk => 'baz' } ] ,
-    'git -a -bfoo --cd --ef=foo status -g -hbar --ij --jk=baz',
+    'git -a -b foo --cd --ef=foo status -g -h bar --ij --jk=baz',
   ] ,
   [
     [ 'rev-list' , qw/ --all --not master / , { remotes => '*trunk*' } , qw/ -- filename / ] ,


### PR DESCRIPTION
This fixes `{ -c => 'foo.bar=baz' }` to pass `( '-c', 'foo.bar=baz' )' (as two list arguments) rather than`-cfoo.bar=baz`, which git does not accept (see`man git` for the -c option).

I couldn't find any cases of git wanting single-letter options without a space (e.g. `{ a => 'foo' }` becoming `-afoo` as opposed to `-a foo`).  I've also added comprehensive test for these permutations and the other option permutations that weren't covered, and sorted the processed keys for consistent test results in newer perls.
