### PR TITLE
Issue-43: When --format is specified with the log method, return everyth...

### DIFF
--- a/lib/Git/Wrapper/Log.pm
+++ b/lib/Git/Wrapper/Log.pm
@@ -36,21 +36,47 @@ sub author { shift->attr->{author} }
 
 1;
 
+=head1 DESCRIPTION
+
+This module is the container for each individual log entry returned when
+L<Git::Wrapper>'s C<log> method is called without the custom C<--format>
+parameter.
+
+The default log format is parsed and accessors for various attributes are
+provided. These attributes are enumerated in the L<METHODS> section below.
+
+See L<Git::Wrapper::Log::Custom> for more information on the container 
+containing the log output when custom formatting is applied.
+
 =head1 METHODS
 
 =head2 new
 
+Class constructor
+
 =head2 modifications
+
+Returns the file modifications associated with the commit, if any
 
 =head2 attr
 
+Returns the file attributes associated with the commit id
+
 =head2 author
+
+Returns the author as parsed from the default log format
 
 =head2 date
 
+Returns the commit date as parsed from the default log format
+
 =head2 id
 
+Returns the commit SHA as parsed from the default log format
+
 =head2 message
+
+Returns the commit message as parsed from the default log format
 
 =head1 SEE ALSO
 

--- a/lib/Git/Wrapper/Log/Custom.pm
+++ b/lib/Git/Wrapper/Log/Custom.pm
@@ -1,0 +1,53 @@
+package Git::Wrapper::Log::Custom;
+# ABSTRACT: Log output of the Git
+
+sub new {
+  my ($class, $id, %arg) = @_;
+  return bless {
+    output => q{},
+    %arg,
+  } => $class;
+}
+
+sub output { @_ > 1 ? ($_[0]->{output} = $_[1]) : $_[0]->{output} }
+
+1;
+
+=head1 DESCRIPTION
+
+This module is the container for the full output when the C<--format> 
+flag is passed as one of the arguments to L<Git::Wrapper>'s C<log> method. 
+
+There is no attempt to parse the custom format specified as there is when
+no custom C<--format> is specified.
+
+=head1 METHODS
+
+=head2 new
+
+Class constructor
+
+=head2 output 
+
+Returns the entire output provided by C<git> when the C<--format> parameter
+is specified.
+
+No attempt is made to parse the output into individual entries. The caller
+may post process the resulting output as they see fit.
+
+=head1 SEE ALSO
+
+=head2 L<Git::Wrapper>
+
+=head2 L<Git::Wrapper::Log>
+
+=head1 REPORTING BUGS & OTHER WAYS TO CONTRIBUTE
+
+The code for this module is maintained on GitHub, at
+L<https://github.com/genehack/Git-Wrapper>. If you have a patch, feel free to
+fork the repository and submit a pull request. If you find a bug, please open
+an issue on the project at GitHub. (We also watch the L<http://rt.cpan.org>
+queue for Git::Wrapper, so feel free to use that bug reporting system if you
+prefer)
+
+=cut

--- a/t/basic.t
+++ b/t/basic.t
@@ -70,11 +70,18 @@ like($rev_list[0], qr/^[a-f\d]{40} FIRST$/);
 
 my $args = $git->supports_log_raw_dates ? { date => 'raw' } : {};
 my @log = $git->log( $args );
-is(@log, 1, 'one log entry');
+is(@log, 1, 'one default format log entry');
+
+isa_ok($log[0], q{Git::Wrapper::Log}, 'entry type is Git::Wrapper::Log');
 
 my $log = $log[0];
 is($log->id, (split /\s/, $rev_list[0])[0], 'id');
 is($log->message, "FIRST\n\n\tBODY\n", "message");
+
+@log = $git->log( "--format=%H" );
+
+is(@log, 1, 'one custom format log entry');
+isa_ok($log[0], q{Git::Wrapper::Log::Custom}, 'entry type is Git::Wrapper::Log::Custom');
 
 SKIP: {
   skip 'testing old git without raw date support' , 1
@@ -96,6 +103,11 @@ SKIP:
 
   $log = $log[0];
   is($log->id, (split /\s/, $rev_list[0])[0], 'id');
+
+  @log = $git->log( "--format=%H" );
+
+  is(@log, 1, 'one custom format log entry');
+  isa_ok($log[0], q{Git::Wrapper::Log::Custom}, 'entry type is Git::Wrapper::Log::Custom');
 }
 
 SKIP:
@@ -166,6 +178,11 @@ SKIP: {
 
     @log = $git->log();
     is(@log, 2, 'two log entries, one with empty commit message');
+
+    @log = $git->log( "--format=%H" );
+
+    is(@log, 1, 'one custom format log entry');
+    isa_ok($log[0], q{Git::Wrapper::Log::Custom}, 'entry type is Git::Wrapper::Log::Custom');
 };
 
 
@@ -189,6 +206,11 @@ for my $arg_test (@arg_tests) {
     my ($arg_log) = $git->log('-n 1');
 
     is $arg_log->message, "$msg\n", "argument test: $descr";
+
+    my @log = $git->log( "--format=%H" );
+
+    is(@log, 1, 'one custom format log entry');
+    isa_ok($log[0], q{Git::Wrapper::Log::Custom}, 'entry type is Git::Wrapper::Log::Custom');
 }
 
 $git->checkout({b => 'new_branch'});


### PR DESCRIPTION
...ing.

This commit addresses Issue 43, which identifies the limitation in G::W that
there is no way to parse out each log entry for custom formats.

The solution is to provide a G::W::Log::Custom wrapper that returns all of
the output from the log method in the specified format with no attempt
to parse this output into individual records.

If the caller of the log method specifies the format, then they are responsible
for parsing the output.

There is the temptation here to all a parse subroutine reference to be passed,
but I would strongly encourage that we not get into the business of parsing
customized git log formats.