### PR TITLE
Added 2 more modules used during testing, but not included in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -41,10 +41,12 @@ my %WriteMakefileArgs = (
     "warnings" => 0
   },
   "TEST_REQUIRES" => {
+    "File::Temp" => 0,
     "File::Path" => 0,
     "File::Spec" => 0,
     "IO::File" => 0,
     "POSIX" => 0,
+    "Sort::Versions" => 0,
     "Test::Deep" => 0,
     "Test::Exception" => 0,
     "Test::More" => 0


### PR DESCRIPTION
Addressing complaint by CPANTS, "This distribution uses a module or a dist in its test suite that's not listed as a build prerequisite. List all modules used in the test suite in META.yml build_requires".