### PR TITLE
Using "--format" with the log method now throws a Git::Wrapper::Exception

### DIFF
--- a/lib/Git/Wrapper.pm
+++ b/lib/Git/Wrapper.pm
@@ -168,6 +168,10 @@ sub has_git_in_path {
 sub log {
   my $self = shift;
 
+  if ( grep /format=/, @_ ) {
+      die Git::Wrapper::Exception->new( error => [qw/--format not allowed. Use the RUN method if you with to use a custom log format./], output => undef, status => 255 );
+  }
+
   my $opt  = ref $_[0] eq 'HASH' ? shift : {};
   $opt->{no_color}         = 1;
   $opt->{pretty}           = 'medium';
@@ -582,7 +586,9 @@ you want ANSI color highlighting, you'll need to bypass via the RUN() method
   my @logs = $git->log;
 
 Instead of giving back an arrayref of lines, the C<log> method returns a list
-of C<Git::Wrapper::Log> objects. They have four methods:
+of C<Git::Wrapper::Log> objects.
+
+There are four methods in a C<Git::Wrapper::Log> objects:
 
 =over
 
@@ -595,6 +601,18 @@ of C<Git::Wrapper::Log> objects. They have four methods:
 =item * message
 
 =back
+
+=head3 Custom log formats
+
+C<log> will throw an exception if it is passed the C<--format> option. The
+reason for this has to do with the fact that the parsing of the full log
+output into C<Git::Wrapper::Log> objects assumes the default format provided
+by `git` itself. Passing C<--format> to the underlying `git log` method affects
+this assumption and the output is no longer able to be processed as intented.
+
+If you wish to specify a custom log format, please use the L<RUN> method
+directly.  The caller will be supplied with the full log output. From there,
+the caller may process the output as it wishes.
 
 =head2 has_git_in_path
 
@@ -761,6 +779,9 @@ values, and then a list of any other arguments.
 
     # while 'RUN('log')' returns an array of chomped lines
     my @log_lines = $git->RUN('log');
+
+    # getting the full of commit SHAs via `git log` by using the '--format' option
+    my @log_lines = $git->RUN('log', '--format=%H');
 
 =head2 ERR
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -76,6 +76,8 @@ my $log = $log[0];
 is($log->id, (split /\s/, $rev_list[0])[0], 'id');
 is($log->message, "FIRST\n\n\tBODY\n", "message");
 
+throws_ok { $git->log( "--format=%H" ) } q{Git::Wrapper::Exception};
+
 SKIP: {
   skip 'testing old git without raw date support' , 1
     unless $git->supports_log_raw_dates;
@@ -168,6 +170,8 @@ SKIP: {
     is(@log, 2, 'two log entries, one with empty commit message');
 };
 
+my @out = $git->RUN('log','--format=%H');
+ok scalar @out == 2, q{using RUN('log','--format=%H') to get all 2 commit SHAs};
 
 # test --message vs. -m
 my @arg_tests = (


### PR DESCRIPTION
Issue 43: Updated Git::Wrapper::log to throw an exception if "--format" is
detected as a passed-in option. A unit test was added to make sure the
exception was thrown in the right case. The POD was updated to underscore
the fact that the log method shall die if "--format" is detected and points
reader to the documentation on the RUN method, which now includes an example
of calling 'log' directly with the '--format' option.