### PR TITLE
Handle score in git log --raw GH #70

### DIFF
--- a/lib/Git/Wrapper.pm
+++ b/lib/Git/Wrapper.pm
@@ -222,7 +222,7 @@ sub log {
 
       # example output:
       # :000000 100644 0000000000000000000000000000000000000000 ce013625030ba8dba906f756967f9e9ca394464a A     foo/bar
-      while(@out and $out[0] =~ m/^\:(\d{6}) (\d{6}) (\w{40}) (\w{40}) (\w{1})\t(.*)$/) {
+      while(@out and $out[0] =~ m/^\:(\d{6}) (\d{6}) (\w{40}) (\w{40}) (\w{1}[0-9]*)\t(.*)$/) {
         push @modifications, Git::Wrapper::File::RawModification->new($6,$5,$1,$2,$3,$4);
         shift @out;
       }

--- a/lib/Git/Wrapper/File/RawModification.pm
+++ b/lib/Git/Wrapper/File/RawModification.pm
@@ -7,9 +7,16 @@ use warnings;
 
 sub new {
   my ($class, $filename, $type, $perms_from, $perms_to, $blob_from, $blob_to) = @_;
+
+  my $score;
+  if ( defined $type && $type =~ s{^(.)([0-9]+)$}{$1} ) {
+    $score = $2;
+  }
+
   return bless {
     filename   => $filename,
     type       => $type,
+    score 	   => $score,
     perms_from => $perms_from,
     perms_to   => $perms_to,
     blob_from  => $blob_from,
@@ -19,6 +26,7 @@ sub new {
 
 sub filename   { shift->{filename} }
 sub type       { shift->{type} }
+sub score       { shift->{score} }
 
 sub perms_from { shift->{perms_from} }
 sub perms_to   { shift->{perms_to} }
@@ -37,6 +45,8 @@ Constructor
 =head2 filename
 
 =head2 type
+
+=head2 score
 
 =head2 perms_from
 


### PR DESCRIPTION
From git diff help a type is optionally followed
by a score (denoting the percentage of similarity
between the source and target of the move or copy)

Status letters C and R are always followed by a score
- C: copy of a file into a new one
- R: renaming of a file