### PR TITLE
Fix test 9 in basic.t with Git >= 2.9

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -74,7 +74,7 @@ is(@log, 1, 'one log entry');
 
 my $log = $log[0];
 is($log->id, (split /\s/, $rev_list[0])[0], 'id');
-is($log->message, "FIRST\n\n\tBODY\n", "message");
+like($log->message, qr/FIRST\n\n(?:        |\t)BODY\n/, "message");
 
 throws_ok { $git->log( "--format=%H" ) } q{Git::Wrapper::Exception};
 


### PR DESCRIPTION
[Git 2.9 Release Notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.9.0.txt)

> The output formats of "git log" that indents the commit log message by
> 4 spaces now expands HT in the log message by default. You can use
> the "--no-expand-tabs" option to disable this.

I've chosen the simple fix of matching the git message against
8 spaces or a TAB.