### PR TITLE
Include dist.ini in the shipped distribution

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,7 +8,6 @@ copyright_year   = 2014
 
 [GatherDir]
 exclude_match    = ^release.*
-exclude_filename = dist.ini
 exclude_filename = INSTALL
 
 [@Filter]


### PR DESCRIPTION
cpan installers ignore it, and it's easier to debug weird configurations if the file is available right on metacpan, rather than having to hunt down the github repo.