### PR TITLE
Issue reproduced on Windows

### DIFF
--- a/t/path_class.t
+++ b/t/path_class.t
@@ -8,11 +8,18 @@ use POSIX qw(strftime);
 use Sort::Versions;
 use Test::Deep;
 use Test::Exception;
+use File::Spec;
+use Cwd qw/abs_path/;
+
+my $DO_WIN32_GETLONGPATHNAME = ($^O eq 'MSWin32') ? eval 'use Win32; 1' : 0;
 
 eval "use Path::Class 0.26; 1" or plan skip_all =>
     "Path::Class 0.26 is required for this test.";
 
-my $tempdir = tempdir(CLEANUP => 1);
+my $tmpdir = File::Spec->tmpdir;
+$tmpdir = Win32::GetLongPathName(abs_path($tmpdir)) if $DO_WIN32_GETLONGPATHNAME;
+
+my $tempdir = tempdir(DIR => $tmpdir, CLEANUP => 1);
 
 my $dir = Path::Class::dir($tempdir);
 


### PR DESCRIPTION
- strawberry-perl-5.26.1.1-32bit-PDL, perl -v says:
This is perl 5, version 26, subversion 1 (v5.26.1) built for MSWin32-x86-multi-thread-64int

- git-scm, git --version says:
git version 2.14.2.windows.2

Output of t/path_class.t says:
fatal: C:\Users\JEAN-D~1.DUR\AppData\Local\Temp\qcBsa4Jatj\baz: 'C:\Users\JEAN-D~1.DUR\AppData\Local\Temp\qcBsa4Jatj\baz' is outside repository

I suspected a problem with the tilde, and forcing the long pathname did
it.

resolve #41