### PR TITLE
Unset (possible) global gpgsign [#91]

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -26,6 +26,9 @@ diag( "Testing git version: " . $version );
 
 $git->init; # 'git init' also added in v1.5.0 so we're safe
 
+# see https://github.com/genehack/Git-Wrapper/issues/91
+$git->config('commit.gpgsign', 'false');
+
 $git->config( 'user.name'  , 'Test User'        );
 $git->config( 'user.email' , 'test@example.com' );
 

--- a/t/path_class.t
+++ b/t/path_class.t
@@ -28,6 +28,9 @@ diag( "Testing git version: " . $version );
 
 $git->init; # 'git init' also added in v1.5.0 so we're safe
 
+# see https://github.com/genehack/Git-Wrapper/issues/91
+$git->config('commit.gpgsign', 'false');
+
 $git->config( 'user.name'  , 'Test User'        );
 $git->config( 'user.email' , 'test@example.com' );
 


### PR DESCRIPTION
I've checked the @powerman's suggestion to invoke `git config commit.gpgsign false` after `git init` and it does fix the test failures in case `commit.gpgsign` is set to `true` in _~/.gitconfig_.