### PR TITLE
remove timing bug in basic.t by ensuring the arg file is done being printed

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -215,12 +215,12 @@ my @arg_tests = (
     ['m',       'short arg w spaces',   'short arg, spaces in val',    ],
 );
 
-my $arg_file = IO::File->new('>' . File::Spec->catfile($dir, qw(argument_testfile)));
-
 for my $arg_test (@arg_tests) {
     my ($flag, $msg, $descr) = @$arg_test;
 
+    my $arg_file = IO::File->new('>' . File::Spec->catfile($dir, qw(argument_testfile)));
     $arg_file->print("$msg\n");
+    $arg_file->close;
     $git->add('argument_testfile');
     $git->commit({ $flag => $msg });
 


### PR DESCRIPTION
On windows it can happen that the arg file write in the loop returns before
the add is started, which causes the add to be a quiet nop, which makes the
commit fail. Forcing the filehandle to close ensures the buffer is emptied.