### PR TITLE
Fix for kwalitee build_prereq_matches_use

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,11 @@ exclude_filename = INSTALL
 
 [=inc::CheckGitConfig]  ; MakeMaker plus another git check
 
+[Prereqs / BuildRequires]
+Pod::Coverage::TrustPod = 0
+Test::Pod = 0
+Test::Pod::Coverage = 0
+
 [Git::NextVersion]
 first_version = 0.018
 


### PR DESCRIPTION
CPANTS reports that these three modules (Pod::Coverage::TrustPod,
Test::Pod, and Test::Pod::Coverage) are used in Test Suite, and
should be declared under build_requires.

Let me also note that you won't need this PR if you merge #94, which would move author tests to `xt/author/` from their current location of `t/`.